### PR TITLE
session設定の追加

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,6 @@
+Rails.application.config.session_store(
+  :cookie_store,
+  key: "_app_session",
+  same_site: :none,
+  secure: Rails.env.production?
+)


### PR DESCRIPTION
デプロイ時にRails側とReact側でサーバーを分けたため、Cookieが届かずログインできないため、新たにsession_store.rbを作成して、ReactとRailsが別ドメインでもCookieを送れるようにした。