### PR TITLE
カレンダー機能の土台作成

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import { GoalsIndex } from "./GoalsIndex";
 import Terms from "./pages/Terms";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import HowToUse from "./pages/HowToUse";
+import { Calendar } from "./Calendar";
 
 function Tracker() {
   return <div className="p-8 text-3xl">トラッカー画面</div>;
@@ -28,6 +29,7 @@ function App() {
         <Route path="/terms" element={<Terms />} />
         <Route path="/privacy-policy" element={<PrivacyPolicy />} />
         <Route path="/how-to-use" element={<HowToUse />} />
+        <Route path="/calendar" element={<Calendar />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/Calendar.jsx
+++ b/frontend/src/Calendar.jsx
@@ -1,0 +1,27 @@
+import { Link, useNavigate } from "react-router-dom";
+import { Header } from "./components/Header";
+import { Button } from "./ui/button";
+
+export function Calendar() {
+  return (
+    <div className="min-h-screen bg-[#eef0fb]">
+      <Header>
+        <Link to="/dashboard">
+          <Button variant="ghost" className="text-base text-slate-900">
+            Top
+          </Button>
+        </Link>
+      </Header>
+
+      <main className="mx-auto max-w-[1400px] px-8 py-10">
+        <h1 className="text-4xl font-semibold">
+          カレンダー
+        </h1>
+
+        <p className="mt-4 text-slate-500">
+          努力記録を表示する画面
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -189,6 +189,14 @@ export function Dashboard() {
           </Button>
         </Link>
 
+        <Link to ="/calendar">
+          <Button
+            variant="outline"
+            className="rounded-xl border-slate-300 px-6 py-5 text-lg hover:bg-slate-50">
+            カレンダー
+          </Button>
+        </Link>
+
         <Button
           onClick={handleLogout}
           variant="ghost"


### PR DESCRIPTION
**実装内容**
カレンダー画面（Calendar.jsx）を新規作成
React Routerに/calendarルートを追加
Dashboardからカレンダー画面へ遷移できるボタンを追加
カレンダー画面のレイアウト（土台）を作成
このPRで実装していない内容

動作確認
Dashboardからカレンダー画面へ遷移できること
/calendarへ直接アクセスできること
エラーなく画面が表示されること

以下の機能は今後のPRで実装予定です。

カレンダー表示機能
カレンダー用APIの作成
努力記録データとの連携
カレンダーのデザイン調整
月切り替え機能
