### PR TITLE
Googleログインのエラー修正

### DIFF
--- a/app/controllers/users/omniauth_redirects_controller.rb
+++ b/app/controllers/users/omniauth_redirects_controller.rb
@@ -3,6 +3,7 @@ module Users
     skip_before_action :authenticate_user!, only: :google_oauth2
 
     def google_oauth2
+      redirect_to user_google_oauth2_omniauth_authorize_path, allow_other_host: true, status: :see_other
     end
   end
 end


### PR DESCRIPTION
## 実装内容

* Googleログイン開始時の遷移先URLを修正しました。

## 修正内容

* Googleログインボタン押下時の遷移先を `/auth/google_oauth2/start` から、Devise + OmniAuth のルーティングに合わせて `/users/auth/google_oauth2` へ変更しました。

## 修正理由

本番環境でGoogleログインを実行した際、存在しない `/auth/google_oauth2/start` にアクセスしてしまい、404エラーが発生していました。

Deviseが提供するGoogle認証開始URLへ遷移するよう修正し、本番環境でもGoogleログインを開始できるよう対応しました。

## 確認内容

* Googleログインボタン押下時にGoogle認証画面へ遷移すること
* Google認証後、正常にログインできること
