### PR TITLE
月を切り替えてもデータが反映されるように変更

### DIFF
--- a/app/controllers/api/calendars_controller.rb
+++ b/app/controllers/api/calendars_controller.rb
@@ -1,9 +1,16 @@
 module Api
   class CalendarsController < ApplicationController
     def show
+      year = params[:year].to_i
+      month = params[:month].to_i
+
+      start_date = Date.new(year, month, 1)
+      end_date = start_date.end_of_month
+
       checked_dates = Checkin
                       .joins(:goal)
                       .where(goals: { user_id: current_user.id })
+                      .where(created_at: start_date.beginning_of_day..end_date.end_of_day)
                       .pluck(:created_at)
                       .map { |created_at| created_at.to_date.to_s }
                       .uniq

--- a/frontend/src/Calendar.jsx
+++ b/frontend/src/Calendar.jsx
@@ -41,10 +41,16 @@ export function Calendar() {
 
   useEffect(() => {
     const fetchCalendar = async () => {
+      setLoading(true);
+      setErrorMessage("");
+      
       try {
-        const response = await fetch(`${API_BASE_URL}/api/calendar`, {
-          credentials: "include",
-        });
+        const response = await fetch(
+          `${API_BASE_URL}/api/calendar?year=${year}&month=${month}`,
+          {
+            credentials: "include",
+          }
+        );
 
         const data = await response.json();
 
@@ -62,7 +68,7 @@ export function Calendar() {
     };
 
     fetchCalendar();
-  }, []);
+  }, [year, month]);
 
   return (
     <div className="min-h-screen bg-[#dff0e7]">


### PR DESCRIPTION
**概要**
カレンダー画面で前月・翌月へ切り替えられる機能を実装しました。また、表示している年月に応じた努力記録のみを取得するようにAPIを改善し、必要なデータだけを取得する構成へ変更しました。

**実装内容**
カレンダー画面に前月・翌月へ切り替える機能を追加
月切り替え時に表示年月（year・month）をAPIへ渡すよう変更
/api/calendar?year=YYYY&month=MM の形式で年月を指定してデータを取得するよう実装
CalendarsController を修正し、指定された年月のCheckinのみ取得するよう変更
joins(:goal) を利用してログインユーザーのGoalに紐づくCheckinを取得
useEffect の依存配列に year と month を追加し、月が切り替わるたびにAPIを再取得するよう変更
月を切り替えるたびに、その月の努力記録（🌱）が正しく表示されることを確認

**変更による改善点**
必要な月のデータのみ取得するため、不要なデータを取得しない効率的なAPI構成へ改善
表示している年月と努力記録が常に一致するようになり、月ごとの振り返りができるようになった
ReactとRails APIが年月を受け渡しながら連携する実装となり、拡張しやすい構成になった