### PR TITLE
カレンダー画面のレスポンシブ対応

### DIFF
--- a/frontend/src/Calendar.jsx
+++ b/frontend/src/Calendar.jsx
@@ -80,17 +80,17 @@ export function Calendar() {
         </Link>
       </Header>
 
-      <main className="mx-auto max-w-[1100px] px-6 py-10">
+      <main className="mx-auto max-w-[1100px] px-3 py-6 sm:px-6 sm:py-10">
         <section className="mb-8 text-center">
           <p className="text-lg font-medium text-green-700">
             Effort Calendar
           </p>
 
-          <h1 className="mt-2 text-4xl font-semibold text-green-900">
+          <h1 className="mt-2 text-3xl font-semibold text-green-900 sm:text-4xl">
             努力の記録
           </h1>
 
-          <p className="mx-auto mt-4 max-w-[620px] text-lg leading-relaxed text-slate-600">
+          <p className="mx-auto mt-4 max-w-[620px] text-base leading-relaxed text-slate-600 sm:text-lg">
             水やりした日をカレンダーで振り返れます。
           </p>
         </section>
@@ -103,30 +103,30 @@ export function Calendar() {
           <p className="mb-4 text-center text-red-600">{errorMessage}</p>
         )}
 
-        <section className="rounded-[32px] border border-green-100 bg-white/90 p-6 shadow-sm">
+        <section className="rounded-2xl border border-green-100 bg-white/90 p-3 shadow-sm sm:rounded-[32px] sm:p-6">
           <div className="mb-6 flex items-center justify-between">
             <button
               type="button"
               onClick={previousMonth}
-              className="rounded-full bg-green-50 px-4 py-2 text-xl text-green-800 hover:bg-green-100"
+              className="rounded-full bg-green-50 px-3 py-2 text-base text-green-800 hover:bg-green-100 sm:px-4 sm:text-xl"
             >
               ◀
             </button>
 
-            <h2 className="text-3xl font-semibold text-slate-900">
+            <h2 className="text-xl font-semibold text-slate-900 sm:text-3xl">
               {year}年{month}月
             </h2>
 
             <button
               type="button"
               onClick={nextMonth}
-              className="rounded-full bg-green-50 px-4 py-2 text-xl text-green-800 hover:bg-green-100"
+              className="rounded-full bg-green-50 px-3 py-2 text-base text-green-800 hover:bg-green-100 sm:px-4 sm:text-xl"
             >
               ▶
             </button>
           </div>
 
-          <div className="grid grid-cols-7 gap-3 text-center">
+          <div className="grid grid-cols-7 gap-1 text-center sm:gap-3">
             {weekDays.map((day) => (
               <div
                 key={day}
@@ -141,7 +141,7 @@ export function Calendar() {
                 return (
                   <div
                     key={`blank-${index}`}
-                    className="min-h-[92px] rounded-2xl"
+                    className="min-h-[54px] rounded-xl sm:min-h-[72px] sm:rounded-2xl md:min-h-[92px]"
                   />
                 );
               }
@@ -156,7 +156,7 @@ export function Calendar() {
               return (
                 <div
                   key={day}
-                  className={`flex min-h-[92px] flex-col items-center justify-center rounded-2xl border text-lg transition ${
+                  className={`flex min-h-[54px] flex-col items-center justify-center rounded-xl border text-sm transition sm:min-h-[72px] sm:rounded-2xl sm:text-base md:min-h-[92px] md:text-lg ${
                     checked
                       ? "border-green-300 bg-green-100 text-green-900"
                       : "border-slate-100 bg-slate-50 text-slate-400"
@@ -164,31 +164,37 @@ export function Calendar() {
                 >
                   <span className="font-medium">{day}</span>
 
-                  {checked && <span className="mt-2 text-2xl">🌱</span>}
+                  {checked && <span className="mt-1 text-lg sm:mt-2 sm:text-2xl">🌱</span>}
                 </div>
               );
             })}
           </div>
         </section>
 
-        <section className="mt-6 grid gap-4 md:grid-cols-3">
-          <div className="rounded-2xl bg-white/80 p-5 text-center shadow-sm">
-            <p className="text-sm text-slate-500">今月の達成日数</p>
-            <p className="mt-2 text-3xl font-semibold text-green-800">
+        <section className="mt-6 grid grid-cols-3 gap-2 sm:gap-4">
+          <div className="rounded-xl bg-white/80 p-3 text-center shadow-sm sm:rounded-2xl sm:p-5">
+            <p className="text-[10px] text-slate-500 sm:text-sm">
+              今月の達成日数
+            </p>
+            <p className="mt-1 text-xl font-semibold text-green-800 sm:mt-2 sm:text-3xl">
               {checkedDates.length}日
             </p>
           </div>
 
-          <div className="rounded-2xl bg-white/80 p-5 text-center shadow-sm">
-            <p className="text-sm text-slate-500">連続記録</p>
-            <p className="mt-2 text-3xl font-semibold text-green-800">
+          <div className="rounded-xl bg-white/80 p-3 text-center shadow-sm sm:rounded-2xl sm:p-5">
+            <p className="text-[10px] text-slate-500 sm:text-sm">
+              連続記録
+            </p>
+            <p className="mt-1 text-xl font-semibold text-green-800 sm:mt-2 sm:text-3xl">
               2日
             </p>
           </div>
 
-          <div className="rounded-2xl bg-white/80 p-5 text-center shadow-sm">
-            <p className="text-sm text-slate-500">連続努力達成回数</p>
-            <p className="mt-2 text-3xl font-semibold text-green-800">
+          <div className="rounded-xl bg-white/80 p-3 text-center shadow-sm sm:rounded-2xl sm:p-5">
+            <p className="text-[10px] text-slate-500 sm:text-sm">
+              努力回数
+            </p>
+            <p className="mt-1 text-xl font-semibold text-green-800 sm:mt-2 sm:text-3xl">
               2回
             </p>
           </div>

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -129,7 +129,7 @@ export function Dashboard() {
       <div className="min-h-screen bg-[#dff0e7]">
         <Header>
           <Link to="/goals/new">
-            <Button className="rounded-xl bg-[#02021f] px-5 py-2 text-base text-white hover:bg-[#111138]">
+            <Button className="rounded-xl bg-[#02021f] px-3 py-2 text-sm text-white hover:bg-[#111138] sm:px-5 sm:text-base">
               目標登録
             </Button>
           </Link>
@@ -137,33 +137,33 @@ export function Dashboard() {
           <Button
             onClick={handleLogout}
             variant="ghost"
-            className="text-base text-slate-900"
+            className="text-sm text-slate-900 sm:text-base"
           >
             ログアウト
           </Button>
         </Header>
 
-        <main className="mx-auto min-h-[calc(100vh-81px)] max-w-[1400px] px-8 py-12">
+        <main className="mx-auto min-h-[calc(100vh-81px)] max-w-[1400px] px-4 py-8 sm:px-8 sm:py-12">
           <FlashMessage message={flashMessage} />
-          
+
           <div className="flex min-h-[calc(100vh-160px)] items-center justify-center">
-            <div className="w-full max-w-[720px] rounded-[28px] border border-slate-200 bg-white/90 px-10 py-12 text-center shadow-sm">
-              <div className="mx-auto mb-6 flex h-28 w-28 items-center justify-center rounded-full bg-green-100">
-                <span className="text-5xl">🌱</span>
+            <div className="w-full max-w-[360px] rounded-3xl border border-slate-200 bg-white/90 p-6 text-center shadow-sm sm:max-w-[720px] sm:px-10 sm:py-12">
+              <div className="mx-auto mb-5 flex h-20 w-20 items-center justify-center rounded-full bg-green-100 sm:mb-6 sm:h-28 sm:w-28">
+                <span className="text-4xl sm:text-5xl">🌱</span>
               </div>
 
-              <h2 className="text-4xl font-semibold text-green-800">
+              <h2 className="text-2xl font-semibold text-green-800 sm:text-4xl">
                 まだ目標がありません
               </h2>
 
-              <p className="mx-auto mt-4 max-w-[520px] text-lg leading-relaxed text-slate-600">
+              <p className="mx-auto mt-4 max-w-[520px] text-base leading-relaxed text-slate-600 sm:text-lg">
                 最初の目標を登録すると、あなたの木が育ち始めます。
                 小さな一歩から、GrowLogを始めましょう。
               </p>
 
               <div className="mt-8">
                 <Link to="/goals/new">
-                  <Button className="rounded-2xl bg-[#02021f] px-10 py-6 text-xl text-white hover:bg-[#111138]">
+                  <Button className="rounded-2xl bg-[#02021f] px-7 py-5 text-base text-white hover:bg-[#111138] sm:px-10 sm:py-6 sm:text-xl">
                     目標を登録する
                   </Button>
                 </Link>
@@ -179,79 +179,77 @@ export function Dashboard() {
     <div className="min-h-screen bg-[#dff0e7]">
       <Header>
         <Link to="/goals/new">
-          <Button className="rounded-xl bg-[#02021f] px-5 py-2 text-base text-white hover:bg-[#111138]">
+          <Button className="rounded-xl bg-[#02021f] px-2 py-2 text-xs whitespace-nowrap text-white hover:bg-[#111138] sm:px-4 sm:text-base">
             目標登録
           </Button>
         </Link>
 
         <Link to="/goals">
-          <Button variant="ghost" className="text-base text-slate-900">
+          <Button
+            variant="ghost"
+            className="px-2 text-xs whitespace-nowrap text-slate-900 sm:px-4 sm:text-base"
+          >
             目標一覧
           </Button>
         </Link>
 
-        <Link to ="/calendar">
-        <Button
-          className="flex items-center gap-2 rounded-xl bg-green-700 px-5 py-2 text-white hover:bg-green-800"
-        >
-          カレンダー
-          <Calendar className="h-5 w-5" />
-        </Button>
+        <Link to="/calendar">
+          <Button className="flex items-center gap-1 rounded-xl bg-green-700 px-2 py-2 text-xs whitespace-nowrap text-white hover:bg-green-800 sm:gap-2 sm:px-5 sm:text-base">
+            カレンダー
+            <Calendar className="h-4 w-4 sm:h-5 sm:w-5" />
+          </Button>
         </Link>
 
         <Button
           onClick={handleLogout}
           variant="ghost"
-          className="text-base text-slate-900"
+          className="px-2 text-xs whitespace-nowrap text-slate-900 sm:px-4 sm:text-base"
         >
           ログアウト
         </Button>
       </Header>
 
-      <main className="mx-auto max-w-[1400px] px-6 py-8">
+      <main className="mx-auto max-w-[1400px] px-4 py-6 sm:px-6 sm:py-8">
         <FlashMessage message={flashMessage} />
-        <div className="mb-8 flex items-center justify-center gap-3 text-[22px] font-medium text-slate-900">
-          <Medal className="h-7 w-7 text-amber-500" />
+
+        <div className="mb-6 flex items-center justify-center gap-2 text-base font-medium text-slate-900 sm:mb-8 sm:gap-3 sm:text-[22px]">
+          <Medal className="h-5 w-5 text-amber-500 sm:h-7 sm:w-7" />
           <span>達成回数: {currentGoal.checkin_count}回</span>
         </div>
 
-
-        
-        <div className="mx-auto max-w-[760px] rounded-[28px] border border-slate-200 bg-white/90 px-8 py-8 shadow-sm">
-          <div className="flex items-center justify-center gap-6">
+        <div className="mx-auto max-w-[440px] rounded-3xl border border-slate-200 bg-white/90 p-5 shadow-sm sm:max-w-[760px] sm:px-8 sm:py-8">
+          <div className="flex items-center justify-center gap-3 sm:gap-6">
             <button
               onClick={() => setCurrentIndex((prev) => Math.max(prev - 1, 0))}
               disabled={currentIndex === 0}
-              className="text-3xl text-slate-500 hover:text-slate-800 disabled:opacity-30"
+              className="text-2xl text-slate-500 hover:text-slate-800 disabled:opacity-30 sm:text-3xl"
             >
               ◀
             </button>
 
-            <h2 className="text-4xl font-medium text-green-700">
+            <h2 className="text-center text-2xl font-medium text-green-700 sm:text-4xl">
               {currentGoal.title}
             </h2>
 
             <button
               onClick={() =>
-                setCurrentIndex((prev) =>
-                  Math.min(prev + 1, goals.length - 1)
-                )
+                setCurrentIndex((prev) => Math.min(prev + 1, goals.length - 1))
               }
               disabled={currentIndex === goals.length - 1}
-              className="text-3xl text-slate-500 hover:text-slate-800 disabled:opacity-30"
+              className="text-2xl text-slate-500 hover:text-slate-800 disabled:opacity-30 sm:text-3xl"
             >
               ▶
             </button>
           </div>
 
-          <div className="mt-8 flex justify-center">
+          <div className="mt-6 flex justify-center sm:mt-8">
             <DashboardTree count={currentGoal.checkin_count} />
           </div>
 
-          <div className="mt-8 flex justify-center">
+          <div className="mt-6 flex justify-center sm:mt-8">
             {currentGoal.today_checked ? (
               <button
-                className="cursor-not-allowed rounded-2xl bg-gray-400 px-14 py-6 text-[26px] text-white"
+                className="cursor-not-allowed rounded-2xl bg-gray-400 px-8 py-5 text-xl text-white sm:px-14 sm:py-6 sm:text-[26px]"
                 disabled
               >
                 水やり済み 🌱
@@ -260,17 +258,17 @@ export function Dashboard() {
               <button
                 onClick={handleCheck}
                 disabled={loading}
-                className="rounded-2xl bg-green-600 px-14 py-6 text-[26px] text-white hover:bg-green-700"
+                className="rounded-2xl bg-green-600 px-10 py-5 text-xl text-white hover:bg-green-700 sm:px-14 sm:py-6 sm:text-[26px]"
               >
-              {loading && (
-                <span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-              )}
-              {loading ? "水やり中..." : "達成"}
+                {loading && (
+                  <span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                )}
+                {loading ? "水やり中..." : "達成"}
               </button>
             )}
           </div>
 
-          <p className="mt-6 text-center text-xl text-slate-600">
+          <p className="mt-5 text-center text-base text-slate-600 sm:mt-6 sm:text-xl">
             継続することで、あなたの木が成長します
           </p>
         </div>

--- a/frontend/src/GoalNew.jsx
+++ b/frontend/src/GoalNew.jsx
@@ -68,7 +68,7 @@ export function GoalNew() {
     <div className="min-h-screen bg-[#dff0e7]">
       <Header>
         <Link to="/dashboard">
-          <Button variant="ghost" className="text-base text-slate-900">
+          <Button variant="ghost" className="text-sm text-slate-900 sm:text-base">
             Top
           </Button>
         </Link>
@@ -76,26 +76,26 @@ export function GoalNew() {
         <Button
           onClick={handleLogout}
           variant="ghost"
-          className="text-base text-slate-900"
+          className="text-sm text-slate-900 sm:text-base"
         >
           ログアウト
         </Button>
       </Header>
 
-      <main className="mx-auto flex min-h-[calc(100vh-81px)] max-w-[1400px] items-center justify-center px-8 py-10">
-        <div className="w-full max-w-[620px] rounded-[28px] border border-slate-200 bg-white px-8 py-10 shadow-sm">
-          <div className="mb-8 text-center">
-            <h2 className="text-4xl font-semibold text-slate-900">
+      <main className="mx-auto flex min-h-[calc(100vh-81px)] max-w-[1400px] items-center justify-center px-4 py-10 sm:px-8 sm:py-16">
+        <div className="mx-auto w-full max-w-[430px] rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:max-w-[620px] sm:p-10">
+          <div className="mb-6 text-center sm:mb-8">
+            <h2 className="text-3xl font-semibold text-slate-900 sm:text-4xl">
               目標登録
             </h2>
-            <p className="mt-4 text-base text-slate-500">
+            <p className="mt-3 text-sm text-slate-500 sm:mt-4 sm:text-base">
               育てたい目標をひとつ決めましょう
             </p>
           </div>
 
-          <form className="space-y-6" onSubmit={handleSubmit}>
+          <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
             <div>
-              <label className="mb-2 block text-xl font-medium text-slate-900">
+              <label className="mb-2 block text-base font-medium text-slate-900 sm:text-xl">
                 目標
               </label>
               <Input
@@ -103,12 +103,12 @@ export function GoalNew() {
                 placeholder="例: 毎日15分散歩する"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
-                className="h-16 rounded-2xl border-0 bg-slate-100 px-5 text-xl placeholder:text-slate-400"
+                className="h-14 rounded-2xl border-0 bg-slate-100 px-4 text-base placeholder:text-slate-400 sm:h-16 sm:px-5 sm:text-xl"
               />
             </div>
 
-            <div className="rounded-2xl bg-green-50 px-5 py-4 text-slate-600">
-              <p className="text-sm leading-relaxed">
+            <div className="rounded-2xl bg-green-50 px-4 py-4 text-slate-600 sm:px-5">
+              <p className="text-xs leading-relaxed sm:text-sm">
                 小さく続けやすい目標がおすすめです。
                 たとえば「毎日筋トレ」よりも「毎日腕立てを5回する」のように、
                 具体的で始めやすい形にすると続けやすくなります。
@@ -121,7 +121,7 @@ export function GoalNew() {
 
             <Button
               type="submit"
-              className="mt-2 h-16 w-full rounded-2xl bg-[#02021f] text-xl font-medium text-white hover:bg-[#111138]"
+              className="mt-2 h-14 w-full rounded-2xl bg-[#02021f] text-lg font-medium text-white hover:bg-[#111138] sm:h-16 sm:text-xl"
             >
               登録する
             </Button>

--- a/frontend/src/GoalsIndex.jsx
+++ b/frontend/src/GoalsIndex.jsx
@@ -91,13 +91,13 @@ export function GoalsIndex() {
     <div className="min-h-screen bg-[#dff0e7]">
       <Header>
         <Link to="/dashboard">
-          <Button variant="ghost" className="text-base text-slate-900">
+          <Button variant="ghost" className="text-sm text-slate-900 sm:text-base">
             Top
           </Button>
         </Link>
 
         <Link to="/goals/new">
-          <Button className="rounded-xl bg-[#02021f] px-5 py-2 text-base text-white hover:bg-[#111138]">
+          <Button className="rounded-xl bg-[#02021f] px-3 py-2 text-sm text-white hover:bg-[#111138] sm:px-5 sm:text-base">
             目標登録
           </Button>
         </Link>
@@ -105,66 +105,75 @@ export function GoalsIndex() {
         <Button
           onClick={handleLogout}
           variant="ghost"
-          className="text-base text-slate-900"
+          className="text-sm text-slate-900 sm:text-base"
         >
           ログアウト
         </Button>
       </Header>
 
-      <main className="mx-auto max-w-[1200px] px-8 py-10">
-        <div className="mb-8 flex items-center justify-between">
-          <h2 className="text-4xl font-semibold text-slate-900">目標一覧</h2>
-          <p className="text-lg text-slate-600">登録数: {goals.length}件</p>
+      <main className="mx-auto max-w-[1200px] px-4 py-8 sm:px-8 sm:py-10">
+        <div className="mb-6 flex flex-col gap-2 sm:mb-8 sm:flex-row sm:items-center sm:justify-between">
+          <h2 className="text-3xl font-semibold text-slate-900 sm:text-4xl">
+            目標一覧
+          </h2>
+
+          <p className="text-base text-slate-600 sm:text-lg">
+            登録数: {goals.length}件
+          </p>
         </div>
 
         {goals.length === 0 ? (
-          <div className="rounded-[28px] border border-slate-200 bg-white/90 px-10 py-12 text-center shadow-sm">
-            <h3 className="text-3xl font-semibold text-green-800">
+          <div className="rounded-3xl border border-slate-200 bg-white/90 p-6 text-center shadow-sm sm:px-10 sm:py-12">
+            <h3 className="text-2xl font-semibold text-green-800 sm:text-3xl">
               まだ目標がありません
             </h3>
-            <p className="mt-4 text-lg text-slate-600">
+
+            <p className="mt-4 text-base text-slate-600 sm:text-lg">
               最初の目標を登録して、木を育て始めましょう。
             </p>
+
             <div className="mt-8">
               <Link to="/goals/new">
-                <Button className="rounded-2xl bg-[#02021f] px-8 py-5 text-lg text-white hover:bg-[#111138]">
+                <Button className="rounded-2xl bg-[#02021f] px-6 py-4 text-base text-white hover:bg-[#111138] sm:px-8 sm:py-5 sm:text-lg">
                   目標を登録する
                 </Button>
               </Link>
             </div>
           </div>
         ) : (
-          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          <div className="grid gap-4 sm:gap-6 md:grid-cols-2 xl:grid-cols-3">
             {goals.map((goal) => (
               <div
                 key={goal.id}
-                className="rounded-[28px] border border-slate-200 bg-white/90 px-6 py-6 shadow-sm"
+                className="rounded-3xl border border-slate-200 bg-white/90 p-5 shadow-sm sm:p-6"
               >
-                <h3 className="text-2xl font-semibold text-green-700">
+                <h3 className="text-xl font-semibold text-green-700 sm:text-2xl">
                   {goal.title}
                 </h3>
 
-                <div className="mt-4 flex items-center gap-2 text-slate-700">
+                <div className="mt-4 flex items-center gap-2 text-sm text-slate-700 sm:text-base">
                   <Medal className="h-5 w-5 text-amber-500" />
                   <span>達成回数: {goal.checkin_count}回</span>
                 </div>
 
-                <p className="mt-3 text-slate-600">
+                <p className="mt-3 text-sm text-slate-600 sm:text-base">
                   成長段階: {goal.tree_stage?.name}
                 </p>
 
-                <p className="mt-2 text-sm text-slate-500">
-                  {goal.today_checked ? "今日は達成済みです" : "今日はまだ未達成です"}
+                <p className="mt-2 text-xs text-slate-500 sm:text-sm">
+                  {goal.today_checked
+                    ? "今日は達成済みです"
+                    : "今日はまだ未達成です"}
                 </p>
 
                 <div className="mt-6 flex gap-3">
-                    <Button 
-                      onClick={() => handleDelete(goal.id)}
-                      variant="outline"
-                      className="flex-1 rounded-xl text-red-600 border-red-300"
-                    >
-                      削除
-                    </Button>
+                  <Button
+                    onClick={() => handleDelete(goal.id)}
+                    variant="outline"
+                    className="flex-1 rounded-xl border-red-300 text-red-600"
+                  >
+                    削除
+                  </Button>
                 </div>
               </div>
             ))}

--- a/frontend/src/Home.jsx
+++ b/frontend/src/Home.jsx
@@ -7,53 +7,52 @@ import { TreeIllustration } from "./TreeIllustration";
 export function Home() {
   return (
     <div className="min-h-screen bg-[#dff0e7]">
-      {/* ヘッダー */}
       <Header>
         <Link to="/login">
-          <Button variant="ghost" className="text-xl">
+          <Button variant="ghost" className="text-sm sm:text-xl">
             ログイン
           </Button>
         </Link>
 
         <Link to="/register">
-          <Button className="rounded-xl bg-[#02021f] px-5 py-2 text-base text-white hover:bg-[#111138]">
+          <Button className="rounded-xl bg-[#02021f] px-3 py-2 text-sm text-white hover:bg-[#111138] sm:px-5 sm:text-base">
             新規登録
           </Button>
         </Link>
       </Header>
 
-      {/* メイン */}
-      <main className="mx-auto flex min-h-[calc(100vh-81px)] max-w-[1400px] items-center justify-between gap-10 px-8 py-16">
-        {/* 左 */}
+      <main className="mx-auto flex min-h-[calc(100vh-81px)] max-w-[1400px] flex-col items-center justify-center gap-10 px-4 py-10 text-center sm:px-8 sm:py-16 lg:flex-row lg:justify-between lg:text-left">
         <div className="max-w-[650px]">
-          <h2 className="mb-8 text-[96px] font-normal leading-[0.95] tracking-tight text-green-800">
+          <h2 className="mb-6 text-5xl font-normal leading-[0.95] tracking-tight text-green-800 sm:mb-8 sm:text-[72px] lg:text-[96px]">
             成長する
             <br />
             あなたの木
           </h2>
 
-          <p className="mb-10 text-[28px] leading-relaxed text-slate-700">
+          <p className="mb-8 text-base leading-relaxed text-slate-700 sm:mb-10 sm:text-2xl lg:text-[28px]">
             毎日の習慣を育てながら、あなただけの木を成長させましょう。
             継続することで、美しい森を作り上げることができます。
           </p>
 
-          <div className="flex items-center gap-6">
+          <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center sm:gap-6 lg:justify-start">
             <Link to="/register">
-              <Button className="rounded-2xl bg-[#02021f] px-10 py-8 text-[32px] text-white hover:bg-[#111138]">
+              <Button className="rounded-2xl bg-[#02021f] px-8 py-6 text-xl text-white hover:bg-[#111138] sm:px-10 sm:py-8 sm:text-[32px]">
                 始める
               </Button>
             </Link>
 
             <Link to="/how-to-use">
-              <Button variant="ghost" className="rounded-2xl bg-[#02021f] px-10 py-8 text-[32px] text-black hover:bg-[#111138]">
+              <Button
+                variant="outline"
+                className="rounded-2xl border-[#02021f] bg-white px-8 py-6 text-xl text-[#02021f] hover:bg-slate-100 sm:px-10 sm:py-8 sm:text-[32px]"
+              >
                 使い方
               </Button>
             </Link>
           </div>
         </div>
 
-        {/* 右 */}
-        <div className="flex flex-1 justify-center">
+        <div className="flex w-full justify-center lg:flex-1">
           <TreeIllustration />
         </div>
       </main>

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -66,30 +66,32 @@ const handleGoogleLogin = () => {
     <div className="min-h-screen bg-[#dff0e7]">
       <Header>
         <Link to="/login">
-          <Button variant="ghost" className="text-xl">
+          <Button variant="ghost" className="text-sm sm:text-xl">
             ログイン
           </Button>
         </Link>
 
         <Link to="/register">
-          <Button className="rounded-xl bg-[#02021f] px-5 py-2 text-base text-white hover:bg-[#111138]">
+          <Button className="rounded-xl bg-[#02021f] px-3 py-2 text-sm text-white hover:bg-[#111138] sm:px-5 sm:text-base">
             新規登録
           </Button>
         </Link>
       </Header>
 
-      <main className="mx-auto flex min-h-[calc(100vh-81px)] max-w-[1400px] items-center justify-center px-8 py-16">
-        <div className="w-full max-w-[520px] rounded-3xl bg-white p-10 shadow-sm">
-          <div className="mb-8 text-center">
-            <h2 className="text-4xl font-semibold text-green-800">ログイン</h2>
-            <p className="mt-3 text-lg text-slate-600">
+      <main className="mx-auto flex min-h-[calc(100vh-81px)] max-w-[1400px] items-center justify-center px-4 py-10 sm:px-8 sm:py-16">
+        <div className="mx-auto w-full max-w-[430px] rounded-3xl bg-white p-6 shadow-sm sm:max-w-[520px] sm:p-10">
+          <div className="mb-6 text-center sm:mb-8">
+            <h2 className="text-3xl font-semibold text-green-800 sm:text-4xl">
+              ログイン
+            </h2>
+            <p className="mt-3 text-base text-slate-600 sm:text-lg">
               GrowLogへようこそ
             </p>
           </div>
 
-          <form className="space-y-6" onSubmit={handleSubmit}>
+          <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
             <div>
-              <label className="mb-2 block text-lg font-medium text-slate-700">
+              <label className="mb-2 block text-base font-medium text-slate-700 sm:text-lg">
                 メールアドレス
               </label>
               <Input
@@ -101,7 +103,7 @@ const handleGoogleLogin = () => {
             </div>
 
             <div>
-              <label className="mb-2 block text-lg font-medium text-slate-700">
+              <label className="mb-2 block text-base font-medium text-slate-700 sm:text-lg">
                 パスワード
               </label>
               <Input
@@ -119,23 +121,24 @@ const handleGoogleLogin = () => {
             <Button
               type="submit"
               disabled={loading}
-              className="w-full rounded-2xl bg-[#02021f] py-6 text-2xl text-white hover:bg-[#111138]"
+              className="w-full rounded-2xl bg-[#02021f] py-5 text-xl text-white hover:bg-[#111138] sm:py-6 sm:text-2xl"
             >
               {loading && (
                 <span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
               )}
               {loading ? "ログイン中..." : "ログイン"}
             </Button>
+
             <Button
               type="button"
               onClick={handleGoogleLogin}
-              className="mt-4 w-full rounded-2xl border border-slate-300 bg-white py-6 text-xl font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 hover:shadow"
+              className="mt-4 w-full rounded-2xl border border-slate-300 bg-white py-5 text-base font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 hover:shadow sm:py-6 sm:text-xl"
             >
               Googleでログイン
             </Button>
           </form>
 
-          <div className="mt-8 text-center text-lg text-slate-600">
+          <div className="mt-6 text-center text-base text-slate-600 sm:mt-8 sm:text-lg">
             アカウントをお持ちでない方は{" "}
             <Link
               to="/register"
@@ -144,8 +147,9 @@ const handleGoogleLogin = () => {
               新規登録
             </Link>
           </div>
-          <div className="mt-8 text-center text-xs text-slate-400 space-x-4">
-            <Link to="/privacy-policy">プライバシーポリシー  </Link>
+
+          <div className="mt-6 flex flex-col items-center gap-2 text-center text-xs text-slate-400 sm:mt-8 sm:flex-row sm:justify-center sm:gap-4">
+            <Link to="/privacy-policy">プライバシーポリシー</Link>
             <Link to="/terms">利用規約</Link>
           </div>
         </div>

--- a/frontend/src/Register.jsx
+++ b/frontend/src/Register.jsx
@@ -65,26 +65,26 @@ const handleGoogleLogin = () => {
     <div className="min-h-screen bg-[#eef0fb]">
       <Header>
         <Link to="/login">
-          <Button variant="ghost" className="text-xl">
+          <Button variant="ghost" className="text-sm sm:text-xl">
             ログイン
           </Button>
         </Link>
       </Header>
 
-      <main className="mx-auto flex min-h-[calc(100vh-81px)] max-w-[1400px] items-center justify-center px-8 py-10">
-        <div className="w-full max-w-[570px] rounded-[28px] border border-slate-200 bg-white px-6 py-8 shadow-sm">
-          <div className="mb-8 text-center">
-            <h2 className="text-4xl font-semibold text-slate-900">
+      <main className="mx-auto flex min-h-[calc(100vh-81px)] max-w-[1400px] items-center justify-center px-4 py-10 sm:px-8 sm:py-16">
+        <div className="mx-auto w-full max-w-[430px] rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:max-w-[570px] sm:p-10">
+          <div className="mb-6 text-center sm:mb-8">
+            <h2 className="text-3xl font-semibold text-slate-900 sm:text-4xl">
               アカウント登録
             </h2>
-            <p className="mt-4 text-base text-slate-500">
+            <p className="mt-3 text-sm text-slate-500 sm:mt-4 sm:text-base">
               新しいアカウントを作成してください
             </p>
           </div>
 
-          <form className="space-y-6" onSubmit={handleSubmit}>
+          <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
             <div>
-              <label className="mb-2 block text-xl font-medium text-slate-900">
+              <label className="mb-2 block text-base font-medium text-slate-900 sm:text-xl">
                 名前
               </label>
               <Input
@@ -92,12 +92,12 @@ const handleGoogleLogin = () => {
                 placeholder="山田太郎"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                className="h-16 rounded-2xl border-0 bg-slate-100 px-5 text-2xl placeholder:text-slate-400"
+                className="h-14 rounded-2xl border-0 bg-slate-100 px-4 text-lg placeholder:text-slate-400 sm:h-16 sm:px-5 sm:text-2xl"
               />
             </div>
 
             <div>
-              <label className="mb-2 block text-xl font-medium text-slate-900">
+              <label className="mb-2 block text-base font-medium text-slate-900 sm:text-xl">
                 メールアドレス
               </label>
               <Input
@@ -105,12 +105,12 @@ const handleGoogleLogin = () => {
                 placeholder="example@email.com"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="h-16 rounded-2xl border-0 bg-slate-100 px-5 text-2xl placeholder:text-slate-400"
+                className="h-14 rounded-2xl border-0 bg-slate-100 px-4 text-lg placeholder:text-slate-400 sm:h-16 sm:px-5 sm:text-2xl"
               />
             </div>
 
             <div>
-              <label className="mb-2 block text-xl font-medium text-slate-900">
+              <label className="mb-2 block text-base font-medium text-slate-900 sm:text-xl">
                 パスワード
               </label>
               <Input
@@ -118,12 +118,12 @@ const handleGoogleLogin = () => {
                 placeholder="6文字以上で入力してください"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="h-16 rounded-2xl border-0 bg-slate-100 px-5 text-2xl placeholder:text-slate-400"
+                className="h-14 rounded-2xl border-0 bg-slate-100 px-4 text-lg placeholder:text-slate-400 sm:h-16 sm:px-5 sm:text-2xl"
               />
             </div>
 
             <div>
-              <label className="mb-2 block text-xl font-medium text-slate-900">
+              <label className="mb-2 block text-base font-medium text-slate-900 sm:text-xl">
                 パスワード（確認）
               </label>
               <Input
@@ -131,7 +131,7 @@ const handleGoogleLogin = () => {
                 placeholder="もう一度パスワードを入力"
                 value={passwordConfirmation}
                 onChange={(e) => setPasswordConfirmation(e.target.value)}
-                className="h-16 rounded-2xl border-0 bg-slate-100 px-5 text-2xl placeholder:text-slate-400"
+                className="h-14 rounded-2xl border-0 bg-slate-100 px-4 text-lg placeholder:text-slate-400 sm:h-16 sm:px-5 sm:text-2xl"
               />
             </div>
 
@@ -142,7 +142,7 @@ const handleGoogleLogin = () => {
             <Button
               type="submit"
               disabled={loading}
-              className="mt-2 h-16 w-full rounded-2xl bg-[#02021f] text-xl font-medium text-white hover:bg-[#111138]"
+              className="mt-2 h-14 w-full rounded-2xl bg-[#02021f] text-lg font-medium text-white hover:bg-[#111138] sm:h-16 sm:text-xl"
             >
               {loading && (
                 <span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
@@ -153,20 +153,24 @@ const handleGoogleLogin = () => {
             <Button
               type="button"
               onClick={handleGoogleLogin}
-              className="mt-4 w-full rounded-2xl border border-slate-300 bg-white py-6 text-xl font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 hover:shadow"
+              className="mt-4 h-14 w-full rounded-2xl border border-slate-300 bg-white text-base font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 hover:shadow sm:h-16 sm:text-xl"
             >
               Googleでログイン
             </Button>
           </form>
 
-          <div className="mt-8 text-center text-xl text-slate-500">
+          <div className="mt-6 text-center text-base text-slate-500 sm:mt-8 sm:text-xl">
             既にアカウントをお持ちですか？{" "}
-            <Link to="/login" className="font-medium text-slate-900 hover:underline">
+            <Link
+              to="/login"
+              className="font-medium text-slate-900 hover:underline"
+            >
               ログイン
             </Link>
           </div>
-          <div className="mt-8 text-center text-xs text-slate-400 space-x-4">
-            <Link to="/privacy-policy">プライバシーポリシー  </Link>
+
+          <div className="mt-6 flex flex-col items-center gap-2 text-center text-xs text-slate-400 sm:mt-8 sm:flex-row sm:justify-center sm:gap-4">
+            <Link to="/privacy-policy">プライバシーポリシー</Link>
             <Link to="/terms">利用規約</Link>
           </div>
         </div>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -12,7 +12,7 @@ export const Header = ({ children }) => {
           </h1>
         </Link>
 
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2">
           {children}
         </div>
       </div>


### PR DESCRIPTION
### 概要
カレンダー画面および下部の統計カード（達成日数、連続記録、努力回数）を、スマートフォンなどの小さな画面でも崩れずに表示できるようレスポンシブ対応を行いました。

### 変更内容
- **メインレイアウトの調整**: 
  - `main` タグのパディングを画面幅に応じて可変に調整（スマホ時は `px-3 py-6`、`sm` 以上で従来の `px-6 py-10`）。
- **見出し・テキストのフォントサイズ調整**:
  - タイトル（「努力の記録」）をスマホ向けに `text-3xl`（`sm` 以上で `text-4xl`）に縮小。
  - サブテキスト（「水やりした日を〜」）をスマホ向けに `text-base`（`sm` 以上で `text-lg`）に調整。
- **カレンダーコンポーネントのレスポンシブ化**:
  - カレンダーの枠（`section`）のパディングと角丸（`rounded`）を画面幅に合わせて最適化。
  - 月切り替えボタンのテキストサイズ・パディング、および年月表示のフォントサイズをスマホ向けに縮小。
  - 日付グリッドの間隔（`gap`）を縮小（スマホ時は `gap-1`、`sm` 以上で `gap-3`）。
  - 日付マスの最小高さ（`min-h`）とテキストサイズを3段階（スマホ: `54px`/`sm`、`sm`: `72px`/`base`、`md`: 従来の `92px`/`lg`）に可変対応。
  - カレンダー内のチェックマーク（🌱）のサイズをスマホ向けに微調整。
- **統計カード（下部エリア）のグリッド対応**:
  - 縦並びから、スマホ時でも横に3列並ぶよう `grid-cols-3` に変更。
  - 画面幅が狭くても文字が溢れないよう、スマホ時のパディング（`p-3`）、ラベルフォントサイズ（`text-[10px]`）、数値のフォントサイズ（`text-xl`）を小さく調整。
  - ラベル文字列を一部簡潔に修正（「連続努力達成回数」 → 「努力回数」）。