### PR TITLE
ダッシュボードのレイアウト変更

### DIFF
--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -1,12 +1,17 @@
-import { Link, useNavigate } from "react-router-dom";
-import { Medal } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+  Link,
+  useLocation,
+  useNavigate,
+} from "react-router-dom";
+import { Calendar } from "lucide-react";
 import { Button } from "./ui/button";
 import { Header } from "./components/Header";
 import { FlashMessage } from "./components/FlashMessage";
-import { useLocation } from "react-router-dom";
-import { DashboardTree } from "./DashboardTree";
-import { useEffect, useState } from "react";
-import { Calendar } from "lucide-react";
+import {
+  DashboardTree,
+  getTreeProgress,
+} from "./DashboardTree";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "";
 
@@ -72,6 +77,8 @@ export function Dashboard() {
 
   const handleCheck = async () => {
     if (currentGoal?.today_checked || !currentGoal) return;
+
+    setLoading(true);
 
     try {
       const response = await fetch(`${API_BASE_URL}/api/checkins`, {
@@ -175,6 +182,12 @@ export function Dashboard() {
     );
   }
 
+  const {
+    nextStage,
+    remainingCount,
+    progressPercent,
+  } = getTreeProgress(currentGoal.checkin_count);
+
   return (
     <div className="min-h-screen bg-[#dff0e7]">
       <Header>
@@ -212,86 +225,196 @@ export function Dashboard() {
       <main className="mx-auto max-w-[1400px] px-4 py-6 sm:px-6 sm:py-8">
         <FlashMessage message={flashMessage} />
 
-        <div className="mb-6 flex items-center justify-center gap-2 text-base font-medium text-slate-900 sm:mb-8 sm:gap-3 sm:text-[22px]">
-          <Medal className="h-5 w-5 text-amber-500 sm:h-7 sm:w-7" />
-          <span>達成回数: {currentGoal.checkin_count}回</span>
-        </div>
-
-      <div className="mx-auto flex max-w-[440px] flex-col gap-5 sm:max-w-[760px] sm:gap-6">
-        {/* 目標名を表示する枠 */}
-        <section className="rounded-3xl border border-slate-200 bg-white/90 px-4 py-5 shadow-sm sm:px-8 sm:py-6">
-          <div className="flex items-center justify-center gap-3 sm:gap-6">
-            <button
-              type="button"
-              onClick={() =>
-                setCurrentIndex((prev) => Math.max(prev - 1, 0))
-              }
-              disabled={currentIndex === 0}
-              className="shrink-0 text-2xl text-slate-500 transition hover:text-slate-800 disabled:opacity-30 sm:text-3xl"
-              aria-label="前の目標を表示"
-            >
-              ◀
-            </button>
-
-            <h2 className="min-w-0 flex-1 break-words text-center text-2xl font-medium text-green-700 sm:text-4xl">
-              {currentGoal.title}
-            </h2>
-
-            <button
-              type="button"
-              onClick={() =>
-                setCurrentIndex((prev) =>
-                  Math.min(prev + 1, goals.length - 1)
-                )
-              }
-              disabled={currentIndex === goals.length - 1}
-              className="shrink-0 text-2xl text-slate-500 transition hover:text-slate-800 disabled:opacity-30 sm:text-3xl"
-              aria-label="次の目標を表示"
-            >
-              ▶
-            </button>
-          </div>
-        </section>
-
-        {/* 木を表示する枠 */}
-        <section className="overflow-hidden rounded-3xl border border-slate-200 bg-white/90 p-4 shadow-sm sm:p-6">
-          <div className="flex justify-center">
+        <div className="mx-auto flex max-w-[440px] flex-col gap-5 sm:max-w-[760px] sm:gap-6">
+          {/* 木の画像カード */}
+          <section className="overflow-hidden rounded-[32px] border border-slate-200 bg-white shadow-sm">
             <DashboardTree count={currentGoal.checkin_count} />
-          </div>
-        </section>
 
-        {/* 達成ボタンと説明文を表示する枠 */}
-        <section className="rounded-3xl border border-slate-200 bg-white/90 px-5 py-6 text-center shadow-sm sm:px-8 sm:py-8">
-          <div className="flex justify-center">
-            {currentGoal.today_checked ? (
-              <button
-                type="button"
-                className="cursor-not-allowed rounded-2xl bg-gray-400 px-8 py-5 text-xl text-white sm:px-14 sm:py-6 sm:text-[26px]"
-                disabled
-              >
-                水やり済み 🌱
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={handleCheck}
-                disabled={loading}
-                className="rounded-2xl bg-green-600 px-10 py-5 text-xl text-white transition hover:bg-green-700 disabled:cursor-not-allowed disabled:opacity-60 sm:px-14 sm:py-6 sm:text-[26px]"
-              >
-                {loading && (
-                  <span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                )}
+            <div className="px-5 py-2 sm:px-8 sm:py-3">
+              <div className="flex items-center justify-between gap-4">
+                <p className="text-sm font-semibold text-slate-800 sm:text-lg">
+                  達成回数：{currentGoal.checkin_count}回
+                </p>
 
-                {loading ? "水やり中..." : "達成"}
-              </button>
-            )}
-          </div>
+                <p className="text-sm font-semibold text-green-700 sm:text-lg">
+                  {nextStage
+                    ? `あと${remainingCount}回で成長`
+                    : "最大まで成長しました"}
+                </p>
+              </div>
 
-          <p className="mt-5 text-base text-slate-600 sm:mt-6 sm:text-xl">
-            継続することで、あなたの木が成長します
-          </p>
-        </section>
-      </div>
+              <div className="mt-4 flex items-center gap-3">
+                <div className="h-3 flex-1 overflow-hidden rounded-full bg-slate-200">
+                  <div
+                    className="h-full rounded-full bg-green-600 transition-all duration-500"
+                    style={{ width: `${progressPercent}%` }}
+                  />
+                </div>
+
+                <span className="w-12 text-right text-sm font-semibold text-slate-700">
+                  {progressPercent}%
+                </span>
+              </div>
+            </div>
+
+            {/* 目標名 */}
+            <div className="px-4 py-4 sm:px-6 sm:py-5">
+              <div className="flex items-center justify-center gap-3 sm:gap-6">
+                <button
+                  type="button"
+                  onClick={() =>
+                    setCurrentIndex((previous) =>
+                      Math.max(previous - 1, 0)
+                    )
+                  }
+                  disabled={currentIndex === 0}
+                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-green-50 text-xl text-green-700 transition hover:bg-green-100 disabled:cursor-not-allowed disabled:opacity-30 sm:h-12 sm:w-12 sm:text-2xl"
+                  aria-label="前の目標を表示"
+                >
+                  ◀
+                </button>
+
+                <h3 className="min-w-0 flex-1 break-words text-center text-xl font-semibold text-black-700 sm:text-3xl">
+                  {currentGoal.title}
+                </h3>
+
+                <button
+                  type="button"
+                  onClick={() =>
+                    setCurrentIndex((previous) =>
+                      Math.min(previous + 1, goals.length - 1)
+                    )
+                  }
+                  disabled={currentIndex === goals.length - 1}
+                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-green-50 text-xl text-green-700 transition hover:bg-green-100 disabled:cursor-not-allowed disabled:opacity-30 sm:h-12 sm:w-12 sm:text-2xl"
+                  aria-label="次の目標を表示"
+                >
+                  ▶
+                </button>
+              </div>
+            </div>
+
+            <div className="border-t border-slate-200" />
+
+            {/* 達成回数と次の成長 */}
+            <div className="px-4 py-5 sm:px-6 sm:py-6">
+              <div className="grid grid-cols-2 gap-3 sm:gap-5">
+                {/* 達成回数 */}
+                <div className="rounded-2xl border border-slate-200 bg-white px-3 py-4 sm:px-5 sm:py-5">
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-amber-50 text-xl sm:h-14 sm:w-14 sm:text-2xl">
+                      🏆
+                    </div>
+
+                    <div>
+                      <p className="text-xs text-slate-500 sm:text-sm">
+                        達成回数
+                      </p>
+
+                      <p className="mt-1 text-3xl font-bold text-slate-900 sm:text-4xl">
+                        {currentGoal.checkin_count}
+                        <span className="ml-1 text-base font-normal text-slate-500 sm:text-lg">
+                          回
+                        </span>
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                {/* 次の成長 */}
+                <div className="rounded-2xl border border-green-200 bg-green-50/40 px-3 py-4 sm:px-5 sm:py-5">
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white text-xl sm:h-14 sm:w-14 sm:text-2xl">
+                      🌱
+                    </div>
+
+                    <div className="min-w-0">
+                      {nextStage ? (
+                        <>
+                          <p className="text-xs text-slate-500 sm:text-sm">
+                            次の成長まで
+                          </p>
+
+                          <p className="mt-1 flex items-baseline whitespace-nowrap font-semibold text-slate-900">
+                            <span className="text-sm sm:text-lg">あと</span>
+
+                            <span className="mx-1 text-4xl font-bold leading-none text-green-700 sm:text-5xl">
+                              {remainingCount}
+                            </span>
+
+                            <span className="text-base sm:text-lg">回</span>
+                          </p>
+                        </>
+                      ) : (
+                        <>
+                          <p className="text-xs text-slate-500 sm:text-sm">
+                            成長状況
+                          </p>
+
+                          <p className="mt-2 text-lg font-bold text-green-700 sm:text-2xl">
+                            最大まで成長
+                          </p>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* 進捗バー */}
+              <div className="mt-6">
+                <div className="mb-2 flex items-center justify-between">
+                  <p className="text-xs font-medium text-slate-500 sm:text-sm">
+                    {nextStage ? "次の成長までの進捗" : "成長進捗"}
+                  </p>
+
+                  <p className="text-sm font-semibold text-slate-700">
+                    {progressPercent}%
+                  </p>
+                </div>
+
+                <div className="h-3 overflow-hidden rounded-full bg-slate-200">
+                  <div
+                    className="h-full rounded-full bg-green-600 transition-all duration-500"
+                    style={{ width: `${progressPercent}%` }}
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="border-t border-slate-200" />
+
+            {/* 達成ボタン */}
+            <div className="px-4 py-5 text-center sm:px-6 sm:py-6">
+              {currentGoal.today_checked ? (
+                <button
+                  type="button"
+                  disabled
+                  className="flex h-14 w-full cursor-not-allowed items-center justify-center rounded-2xl bg-slate-400 text-lg font-semibold text-white sm:h-16 sm:text-xl"
+                >
+                  水やり済み 🌱
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleCheck}
+                  disabled={loading}
+                  className="flex h-14 w-full items-center justify-center rounded-2xl bg-green-600 text-lg font-semibold text-white transition hover:bg-green-700 disabled:cursor-not-allowed disabled:opacity-60 sm:h-16 sm:text-xl"
+                >
+                  {loading && (
+                    <span className="mr-3 inline-block h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                  )}
+
+                  {loading ? "水やり中..." : "💧 水やりする"}
+                </button>
+              )}
+
+              <p className="mt-5 text-sm text-slate-600 sm:text-lg">
+                継続することで、あなたの木が成長します
+              </p>
+            </div>
+          </section>
+        </div>
       </main>
     </div>
   );

--- a/frontend/src/DashboardTree.jsx
+++ b/frontend/src/DashboardTree.jsx
@@ -26,7 +26,7 @@ const treeStages = [
   },
   {
     min: 15,
-    max: 60,
+    max: 79,
     image: "/images/trees/tree-stage-15.png",
   },
   {
@@ -36,23 +36,59 @@ const treeStages = [
   },
 ];
 
-function getStage(count) {
-  return (
-    treeStages.find(
-      (stage) => count >= stage.min && count <= stage.max
-    ) || treeStages[0]
+export function getTreeProgress(checkinCount) {
+  // 条件を満たす中で、最も高い成長段階を取得
+  const currentStage =
+    [...treeStages]
+      .reverse()
+      .find((stage) => checkinCount >= stage.min) || treeStages[0];
+
+  // 現在の成長段階が配列の何番目かを取得
+  const currentStageIndex = treeStages.findIndex(
+    (stage) => stage === currentStage
   );
-}
 
+  // 次の成長段階を取得
+  const nextStage = treeStages[currentStageIndex + 1] || null;
+
+  // すでに最終段階の場合
+  if (!nextStage) {
+    return {
+      currentStage,
+      nextStage: null,
+      remainingCount: 0,
+      progressPercent: 100,
+    };
+  }
+
+  // あと何回で次の段階に成長するか
+  const remainingCount = Math.max(
+    nextStage.min - checkinCount,
+    0
+  );
+
+  // 次の成長に必要な回数に対する進捗率
+  const progressPercent = Math.min(
+    Math.round((checkinCount / nextStage.min) * 100),
+    100
+  );
+
+  return {
+    currentStage,
+    nextStage,
+    remainingCount,
+    progressPercent,
+  };
+}
 export function DashboardTree({ count }) {
-  const stage = getStage(count);
+  const { currentStage } = getTreeProgress(count);
 
   return (
-    <div className="w-full">
+    <div className="aspect-[16/7] w-full overflow-hidden">
       <img
-        src={stage.image}
+        src={currentStage.image}
         alt="木の成長"
-        className="w-full rounded-[32px] object-cover"
+        className="h-full w-full object-cover object-[center_58%]"
       />
     </div>
   );

--- a/frontend/src/components/FlashMessage.jsx
+++ b/frontend/src/components/FlashMessage.jsx
@@ -1,9 +1,25 @@
+import { useEffect, useState } from "react";
+
 export function FlashMessage({ message }) {
-  if (!message) return null;
+  const [visibleMessage, setVisibleMessage] = useState(message);
+
+  useEffect(() => {
+    setVisibleMessage(message);
+
+    if (!message) return;
+
+    const timer = setTimeout(() => {
+      setVisibleMessage("");
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, [message]);
+
+  if (!visibleMessage) return null;
 
   return (
     <div className="mb-6 rounded-2xl bg-green-100 px-5 py-4 text-green-700">
-      {message}
+      {visibleMessage}
     </div>
   );
 }


### PR DESCRIPTION
## 概要

ダッシュボード画面のUIを改善し、木の成長をより視覚的に楽しめるレイアウトへ変更しました。

## 変更内容

### ダッシュボード画面
- 木の画像を横長レイアウトへ変更
- 木の画像と進捗情報を一体感のあるカードデザインへ変更
- 目標名・進捗情報・達成ボタンを1枚のカードにまとめてレイアウトを整理
- 達成回数カードと次の成長カードのデザインを改善
- プログレスバーのレイアウトを調整
- 各カードの余白・サイズを見直し、全体をコンパクトなデザインへ変更
- ボタンやカードの配色・余白を調整し、統一感を向上

### 木の成長表示
- `getTreeProgress` を利用して現在の成長段階・次の成長までの回数・進捗率を表示
- 木の画像を達成回数に応じて切り替えるよう実装

### フラッシュメッセージ
- フラッシュメッセージを3秒後に自動で非表示になるよう変更
