### PR TITLE
リマインダメールの送信時刻の設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,9 @@ module App
       g.test_framework nil
     end
 
+    config.time_zone = "Tokyo"
+    config.active_record.default_timezone = :local
+
     config.active_job.queue_adapter = :sidekiq
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,0 +1,5 @@
+daily_reminder_job:
+  cron: "0 20 * * * Asia/Tokyo"
+  class: "DailyReminderJob"
+  queue: default
+  description: "毎日20時に未達成ユーザーへリマインドメールを送る"

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,10 +3,3 @@
 :queues:
   - default
   - mailers
-
-:scheduler:
-  :schedule:
-    daily_reminder:
-      cron: "0 20 * * * Asia/Tokyo"
-      class: "DailyReminderJob"
-      queue: default


### PR DESCRIPTION
実装内容
sidekiq-cron を利用し、毎日20:00に DailyReminderJob が自動実行されるよう定期実行を設定
config/schedule.yml を作成し、リマインドメール送信ジョブのスケジュールを管理するよう実装
動作確認のため、一時的に5分ごとの実行へ変更し、定期実行によるメール送信を確認
動作確認後、スケジュールを毎日20:00の設定へ戻した
動作確認
sidekiq-cron により、設定したスケジュールで DailyReminderJob が実行されることを確認
リマインドメールが正常に送信されることを確認
動作確認後、スケジュールを毎日20:00に戻したことを確認