### PR TITLE
本番環境でもResendを利用したメール送信が正常に行えるよう、Action Mailerおよび独自ドメインの設定を追加しました。

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,6 +78,26 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
 
+  # URL生成用
+  config.action_mailer.default_url_options = {
+    host: "growlog-jp.com",
+    protocol: "https"
+  }
+
+  # SMTP設定（Resend）
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+
+  config.action_mailer.smtp_settings = {
+    address: "smtp.resend.com",
+    port: 587,
+    user_name: "resend",
+    password: ENV.fetch("RESEND_API_KEY"),
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,11 +1,15 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "http://localhost:5173",
-            "https://growlog-front.onrender.com"
+    origins(
+      "http://localhost:5173",
+      "https://growlog-jp.com",
+      "https://www.growlog-jp.com",
+      "https://growlog-front.onrender.com"
+    )
 
     resource "*",
-      headers: :any,
-      methods: [ :get, :post, :patch, :put, :delete, :options, :head ],
-      credentials: true
+             headers: :any,
+             methods: %i[get post put patch delete options head],
+             credentials: true
   end
 end


### PR DESCRIPTION
実装内容
Resendに独自ドメイン（growlog-jp.com）を登録し、メール送信ドメインを認証
XServerのDNSへResend用のDKIM・SPFレコードを追加
本番環境（production.rb）へAction MailerのSMTP設定を追加
smtp.resend.com を利用
RESEND_API_KEY を使用したSMTP認証を設定
本番環境のdefault_url_optionsを独自ドメイン（https://growlog-jp.com）へ変更
Renderの環境変数を設定
RESEND_API_KEY
MAIL_FROM
ApplicationMailerの送信元メールアドレスを環境変数（MAIL_FROM）から取得する設定を利用