### PR TITLE
Googleログインのエラー解消

### DIFF
--- a/app/controllers/users/omniauth_redirects_controller.rb
+++ b/app/controllers/users/omniauth_redirects_controller.rb
@@ -3,7 +3,6 @@ module Users
     skip_before_action :authenticate_user!, only: :google_oauth2
 
     def google_oauth2
-      redirect_to user_google_oauth2_omniauth_authorize_path, allow_other_host: true, status: :see_other
     end
   end
 end

--- a/frontend/src/Calendar.jsx
+++ b/frontend/src/Calendar.jsx
@@ -186,7 +186,7 @@ export function Calendar() {
               連続記録
             </p>
             <p className="mt-1 text-xl font-semibold text-green-800 sm:mt-2 sm:text-3xl">
-              2日
+              1日
             </p>
           </div>
 
@@ -195,7 +195,7 @@ export function Calendar() {
               努力回数
             </p>
             <p className="mt-1 text-xl font-semibold text-green-800 sm:mt-2 sm:text-3xl">
-              2回
+              1回
             </p>
           </div>
         </section>


### PR DESCRIPTION
## 概要
Googleログイン時に404エラーが発生していたため、Google認証フローを修正しました。

## 変更内容
- `OmniauthRedirectsController` の `redirect_to` を削除
- `google_oauth2.html.erb` を経由し、自動POSTで `/users/auth/google_oauth2` にリクエストを送信するよう修正
- React側のGoogleログインボタンから `/auth/google_oauth2/start` に遷移し、正常にGoogle認証が開始されるよう修正

## 修正前
`/auth/google_oauth2/start` から `redirect_to` により `/users/auth/google_oauth2` へGETリクエストが送信されており、POST専用ルートへGETアクセスしてしまうため404エラーが発生していました。

## 修正後
`/auth/google_oauth2/start` で自動送信フォームを表示し、POSTリクエストで `/users/auth/google_oauth2` を呼び出すように変更しました。
これにより、Google認証画面へ正常に遷移できるようになりました。

## 確認項目
- [x] GoogleログインボタンからGoogle認証画面へ遷移できること
- [x] Googleアカウントでログインできること