### PR TITLE
GoogleログインのCSSのエラー解消

### DIFF
--- a/app/controllers/users/omniauth_redirects_controller.rb
+++ b/app/controllers/users/omniauth_redirects_controller.rb
@@ -3,6 +3,7 @@ module Users
     skip_before_action :authenticate_user!, only: :google_oauth2
 
     def google_oauth2
+      render layout: false
     end
   end
 end


### PR DESCRIPTION
application.cssが存在しないが、ログの処理の流れ上だと application.cssを読み込もうとし、存在しないため500エラーが発生していた。
render layout: false を追加して、application.cssを読み込まない様にコード変更した。